### PR TITLE
wrong column numbering in `names2str()` function

### DIFF
--- a/src/dump.py
+++ b/src/dump.py
@@ -589,9 +589,9 @@ class dump:
   # convert column names assignment to a string, in column order
   
   def names2str(self):
-    ncol = max(self.names.values()) #len(self.snaps[0].atoms[0])
     pairs = self.names.items()
     values = self.names.values()
+    ncol = len(pairs)
     str = ""
     for i in xrange(ncol):
       if i in values: str += pairs[values.index(i)][0] + ' '


### PR DESCRIPTION
This PR corrects a wrong numbering of the columns:
https://github.com/CFDEMproject/LPP/blob/633058e1abb8b9bea1f9e6e47ceae8376ad3661a/src/dump.py#L592

For N entries, the `self.names` dictionary keys go from 0 to N-1, hence the above-quoted line returns `ncol = N-1` instead of `ncol = N`

In the original pizza.py `names2str()` function, the number of columns is given by `ncol = len(pairs)` which returns the correct number of columns